### PR TITLE
fix: missing merge values logic

### DIFF
--- a/operator/controllers/helm_merge_maps.go
+++ b/operator/controllers/helm_merge_maps.go
@@ -1,0 +1,39 @@
+/*
+Copyright The Helm Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+// mergeMaps was copied from the Helm source. Refer to the original code:
+// https://github.com/helm/helm/blob/6297c021cbda1483d8c08a8ec6f4a99e38be7302/pkg/cli/values/options.go#L88
+// Any eventual changes to the original function must be documented accordingly.
+func mergeMaps(a, b map[string]interface{}) map[string]interface{} {
+	out := make(map[string]interface{}, len(a))
+	for k, v := range a {
+		out[k] = v
+	}
+	for k, v := range b {
+		if v, ok := v.(map[string]interface{}); ok {
+			if bv, ok := out[k]; ok {
+				if bv, ok := bv.(map[string]interface{}); ok {
+					out[k] = mergeMaps(bv, v)
+					continue
+				}
+			}
+		}
+		out[k] = v
+	}
+	return out
+}

--- a/operator/controllers/instance_controller.go
+++ b/operator/controllers/instance_controller.go
@@ -201,15 +201,15 @@ func mergeValues(
 ) ([]byte, error) {
 	userValues := make(map[string]interface{})
 	if err := yaml.Unmarshal([]byte(instance.Spec.Values), &userValues); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to unmarshal user-provided values: %w", err)
 	}
 	defaultValues := make(map[string]interface{})
 	if err := yaml.Unmarshal([]byte(plan.Spec.Provisioning.Values.Default), &defaultValues); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to unmarshal default plan values: %w", err)
 	}
 	staticValues := make(map[string]interface{})
 	if err := yaml.Unmarshal([]byte(plan.Spec.Provisioning.Values.Static), &staticValues); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to unmarshal static plan values: %w", err)
 	}
 	values := make(map[string]interface{})
 	values = mergeMaps(values, defaultValues)


### PR DESCRIPTION
The plan provides default and static values. They should be merged accordingly with the user-provided to form the final values used to provision an Instance.