### PR TITLE
refactor: image build scripts

### DIFF
--- a/examples/packages/postgres-metabroker/images/build.sh
+++ b/examples/packages/postgres-metabroker/images/build.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -o errexit -o nounset -o pipefail
+
+: "${IMAGE_TAG:=postgres-metabroker-credential}"
+
+cd "$(dirname "${0}")"
+
+docker buildx build \
+    --tag "${IMAGE_TAG}" \
+    --file "Dockerfile.credential" .

--- a/images/build.sh
+++ b/images/build.sh
@@ -2,10 +2,10 @@
 
 set -o errexit -o nounset -o pipefail
 
-: "${IMAGE_TAG:=postgres-metabroker-credential}"
+: "${IMAGE_TAG:=metabroker-provisioning}"
 
 cd "$(dirname "${0}")"
 
 docker buildx build \
     --tag "${IMAGE_TAG}" \
-    --file "images/Dockerfile.credential" .
+    --file "Dockerfile.provisioning" .


### PR DESCRIPTION
- Moved the example `build.sh` for the image to the `images` directory.
- Copied the `build.sh` script to the provisioning image.