### PR TITLE
feat: add finalizers to Instances and Credentials

### DIFF
--- a/operator/api/v1alpha1/credential_types.go
+++ b/operator/api/v1alpha1/credential_types.go
@@ -19,7 +19,11 @@ package v1alpha1
 import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/SUSE/metabroker/operator/stringutil"
 )
+
+const credentialUnbindingFinalizer = "unbinding.credentials.servicebroker.metabroker.suse.com"
 
 // +kubebuilder:object:root=true
 
@@ -37,6 +41,30 @@ type Credential struct {
 	SecretRef corev1.LocalObjectReference `json:"secretRef"`
 	// The observed state of the Credential.
 	Status CredentialStatus `json:"status,omitempty"`
+}
+
+// IsDeleting returns whether the Credential was marked for deletion but was not deleted yet. This
+// is useful for checking when finalizers are present.
+func (credential *Credential) IsDeleting() bool {
+	return !credential.ObjectMeta.DeletionTimestamp.IsZero()
+}
+
+// HasUnbindingFinalizer returns whether the Credential has the unbinding finalizer.
+func (credential *Credential) HasUnbindingFinalizer() bool {
+	return stringutil.Contains(credential.ObjectMeta.Finalizers, credentialUnbindingFinalizer)
+}
+
+// AddUnbindingFinalizer appends the unbinding finalizer to the Credential finalizers.
+func (credential *Credential) AddUnbindingFinalizer() {
+	credential.ObjectMeta.Finalizers = append(credential.ObjectMeta.Finalizers, credentialUnbindingFinalizer)
+}
+
+// RemoveUnbindingFinalizer removes the unbinding finalizer from the Credential finalizers.
+func (credential *Credential) RemoveUnbindingFinalizer() {
+	credential.ObjectMeta.Finalizers = stringutil.Remove(
+		credential.ObjectMeta.Finalizers,
+		credentialUnbindingFinalizer,
+	)
 }
 
 // +kubebuilder:object:root=true

--- a/operator/controllers/instance_controller.go
+++ b/operator/controllers/instance_controller.go
@@ -39,6 +39,7 @@ import (
 
 	servicebrokerv1alpha1 "github.com/SUSE/metabroker/operator/api/v1alpha1"
 	"github.com/SUSE/metabroker/operator/helm"
+	"github.com/SUSE/metabroker/operator/stringutil"
 )
 
 // InstanceReconciler implements the Reconcile method for the Instance resource.
@@ -69,9 +70,10 @@ func NewInstanceReconciler(
 // +kubebuilder:rbac:groups=servicebroker.metabroker.suse.com,resources=instances/status,verbs=get;update;patch
 
 const (
-	instanceReconcileTimeout = 30 * time.Second
-	helmInstallTimeout       = 5 * time.Minute
-	helmUninstallTimeout     = 3 * time.Minute
+	instanceReconcileTimeout        = 30 * time.Second
+	instanceDeprovisioningFinalizer = "deprovisioning.instances.servicebroker.metabroker.suse.com"
+	helmInstallTimeout              = 5 * time.Minute
+	helmUninstallTimeout            = 3 * time.Minute
 )
 
 // Reconcile reconciles an Instance resource.
@@ -86,17 +88,41 @@ func (r *InstanceReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	instance := &servicebrokerv1alpha1.Instance{}
 	if err := r.Get(ctx, req.NamespacedName, instance); err != nil {
 		if errors.IsNotFound(err) {
-			// The instance no longer exists; run any deprovisioning steps necessary.
+			log.Info("Instance deleted")
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, err
+	}
+
+	// The Instance is set for deletion, pending finalizers.
+	if !instance.ObjectMeta.DeletionTimestamp.IsZero() {
+		if stringutil.Contains(instance.ObjectMeta.Finalizers, instanceDeprovisioningFinalizer) {
+			log.Info("Instance being deleted; deprovisioning...")
 			uninstallOpts := helm.UninstallOpts{
 				Namespace: helm.NamespaceOpt(releaseReq.Namespace),
 				Timeout:   helmUninstallTimeout,
 			}
-			if err := r.helm.Uninstall(releaseReq.ReleaseName(), uninstallOpts); err != nil {
+			if err := r.helm.Uninstall(instance.HelmRef.Name, uninstallOpts); err != nil {
 				return ctrl.Result{}, err
 			}
-			return ctrl.Result{}, nil
+
+			instance.ObjectMeta.Finalizers = stringutil.Remove(
+				instance.ObjectMeta.Finalizers,
+				instanceDeprovisioningFinalizer,
+			)
+			if err := r.Update(ctx, instance); err != nil {
+				return ctrl.Result{}, err
+			}
 		}
-		return ctrl.Result{}, err
+		return ctrl.Result{}, nil
+	}
+
+	// Add finalizer.
+	if !stringutil.Contains(instance.ObjectMeta.Finalizers, instanceDeprovisioningFinalizer) {
+		instance.ObjectMeta.Finalizers = append(instance.ObjectMeta.Finalizers, instanceDeprovisioningFinalizer)
+		if err := r.Update(ctx, instance); err != nil {
+			return ctrl.Result{}, err
+		}
 	}
 
 	planNamespacedName := req.NamespacedName

--- a/operator/stringutil/strings.go
+++ b/operator/stringutil/strings.go
@@ -1,0 +1,21 @@
+package stringutil
+
+// Contains returns whether the string `s` is contained in `slice`.
+func Contains(slice []string, s string) bool {
+	for _, item := range slice {
+		if item == s {
+			return true
+		}
+	}
+	return false
+}
+
+// Remove returns a new slice with `s` removed from `slice`.
+func Remove(slice []string, s string) []string {
+	for i, item := range slice {
+		if item == s {
+			return append(slice[:i], slice[i+1:]...)
+		}
+	}
+	return slice
+}

--- a/operator/stringutil/strings.go
+++ b/operator/stringutil/strings.go
@@ -1,6 +1,6 @@
 package stringutil
 
-// Contains returns whether the string `s` is contained in `slice`.
+// Contains returns whether `slice` contains the string `s` or not.
 func Contains(slice []string, s string) bool {
 	for _, item := range slice {
 		if item == s {
@@ -10,7 +10,7 @@ func Contains(slice []string, s string) bool {
 	return false
 }
 
-// Remove returns a new slice with `s` removed from `slice`.
+// Remove returns a new slice with the first match of `s` removed from `slice`.
 func Remove(slice []string, s string) []string {
 	for i, item := range slice {
 		if item == s {


### PR DESCRIPTION
A finalizer for deprovisioning an Instance is important for using the stored helmRef.name rather than calculating the name again. This makes upgrades with potentially changing calculated names more robust.

A finalizer for unbinding a Credential is important for having access to the generated Secret with the binding information before it is gone with the Credential deleted.